### PR TITLE
Change phone=* to contact:phone=* with consistent number format

### DIFF
--- a/osm_poi_matchmaker/dataproviders/hu_ccc.py
+++ b/osm_poi_matchmaker/dataproviders/hu_ccc.py
@@ -30,7 +30,7 @@ class hu_ccc(DataProvider):
                      'operator:addr': '1123 Budapest, Alkotás utca 53.', 'ref:HU:vatin': '24128296-2-44',
                      'ref:vatin': 'HU24128296', 'ref:HU:company': '01-09-991763', 'brand': 'CCC', 'brand:wikidata': 'Q11788344',
                      'brand:wikipedia': 'pl:CCC (przedsiębiorstwo)', 'contact:email': 'info.hu@ccc.eu',
-                     'phone': '+36 1 445 3701', 'contact:linkedin': 'https://www.linkedin.com/company/cccsa',
+                     'contact:phone': '+36 1 445 3701', 'contact:linkedin': 'https://www.linkedin.com/company/cccsa',
                      'contact:facebook': 'https://www.facebook.com/CCC.Hungary/',
                      'contact:youtube': 'https://www.youtube.com/channel/UCVscWDmL_2JddDdGuku7f2w',
                      'contact:instagram': 'https://www.instagram.com/cccshoesbags_hu/', 'air_conditioning': 'yes'}

--- a/osm_poi_matchmaker/dataproviders/hu_deichmann.py
+++ b/osm_poi_matchmaker/dataproviders/hu_deichmann.py
@@ -29,7 +29,7 @@ class hu_deichmann(DataProvider):
                      'operator:addr': '1134 Budapest, Kassák Lajos utca 19-25. 6. emelet', 'ref:HU:vatin': '12583083-2-44',
                      'ref:vatin': 'HU12583083', 'ref:HU:company': '01-09-693582', 'brand': 'Deichmann', 'brand:wikidata': 'Q11788344',
                      'brand:wikipedia': 'hu:Deichmann', 'contact:email': 'ugyfelszolgalat@deichmann.com',
-                     'phone': '+36 80 840 840',
+                     'contact:phone': '+36 80 840 840',
                      'contact:facebook': 'https://www.facebook.com/Deichmann.HU/',
                      'contact:youtube': 'https://www.youtube.com/user/Deichmann/',
                      'contact:instagram': 'https://www.instagram.com/deichmannhu/',

--- a/osm_poi_matchmaker/dataproviders/hu_easybox.py
+++ b/osm_poi_matchmaker/dataproviders/hu_easybox.py
@@ -28,7 +28,7 @@ class hu_easybox(DataProvider):
                      'operator:addr': '1033 Budapest, Szentendrei út 89-95. X. épület', 'ref:vatin': 'HU28730978',
                      'ref:HU:vatin': '28730978-2-41', 'ref:HU:company': ' 01-09-371417 ',
                      'contact:youtube': 'https://www.youtube.com/channel/UC-lcPt3u8bHUj9hwKRNYTTQ',
-                     'contact:email': 'info@sameday.hu', 'contact:phone': '+36 1 374 3890',
+                     'contact:email': 'info@sameday.hu', 'contact:phone': '+36 1 374 3890',
                      'payment:contactless': 'yes', 'payment:mastercard': 'yes', 'payment:visa': 'yes',
                      'payment:cash': 'no', }
         self.filetype = FileType.json

--- a/osm_poi_matchmaker/dataproviders/hu_foxpost.py
+++ b/osm_poi_matchmaker/dataproviders/hu_foxpost.py
@@ -32,7 +32,7 @@ class hu_foxpost(DataProvider):
                      'ref:HU:vatin': '25034644-2-10', 'ref:HU:company': '10-10-020309',
                      'contact:facebook': 'https://www.facebook.com/foxpostzrt',
                      'contact:youtube': 'https://www.youtube.com/channel/UC3zt91sNKPimgA32Nmcu97w',
-                     'contact:email': 'info@foxpost.hu', 'contact:phone': '+36 1 999 03 69',
+                     'contact:email': 'info@foxpost.hu', 'contact:phone': '+36 1 999 0369',
                      'payment:contactless': 'yes', 'payment:mastercard': 'yes', 'payment:visa': 'yes',
                      'payment:cash': 'no', }
         self.filetype = FileType.json

--- a/osm_poi_matchmaker/dataproviders/hu_mav.py
+++ b/osm_poi_matchmaker/dataproviders/hu_mav.py
@@ -33,7 +33,7 @@ class hu_mav(DataProvider):
                      'operator:addr': '1087 Budapest, Könyves Kálmán körút 54-60.', 'ref:HU:vatin': '13834492-2-44',
                      'ref:vatin': 'HU13834492', 'brand': 'MÁV-START', 'brand:wikidata': 'Q1180332',
                      'brand:wikipedia': 'hu:MÁV-START_Zrt.', 'contact:email': 'eszrevetel@mav-start.hu',
-                     'phone': '+36 1 349 4949',
+                     'contact:phone': '+36 1 349 4949',
                      'contact:facebook': 'https://www.facebook.com/mavstarthungary',
                      'contact:youtube': 'https://www.youtube.com/channel/UCcc8H-ND98GVF5OM5jJphWw',
                      'contact:instagram': 'https://www.instagram.com/mavstart'}

--- a/osm_poi_matchmaker/dataproviders/hu_posta.py
+++ b/osm_poi_matchmaker/dataproviders/hu_posta.py
@@ -28,7 +28,7 @@ class hu_posta(DataProvider):
         self.tags = {'operator': 'Magyar Posta Zrt.',
                      'operator:addr': '1138 Budapest, Dunavirág utca 2-6.', 'ref:HU:vatin': '10901232-2-44',
                      'ref:vatin': 'HU10901232', 'brand:wikipedia': 'hu:Magyar Posta Zrt.', 'brand:wikidata': 'Q145614',
-                     'contact:email': 'ugyfelszolgalat@posta.hu', 'phone': '+3617678200',
+                     'contact:email': 'ugyfelszolgalat@posta.hu', 'contact:phone': '+36 1 767 8200',
                      'contact:facebook': 'https://www.facebook.com/MagyarPosta',
                      'contact:youtube': 'https://www.youtube.com/user/magyarpostaofficial',
                      'contact:instagram': 'https://www.instagram.com/magyar_posta_zrt', 'payment:cash': 'yes',

--- a/osm_poi_matchmaker/dataproviders/hu_posta_json.py
+++ b/osm_poi_matchmaker/dataproviders/hu_posta_json.py
@@ -31,7 +31,7 @@ class hu_posta_json(DataProvider):
         self.link = link
         self.tags = {'brand': 'Magyar Posta', 'operator': 'Magyar Posta Zrt.', 'ref:HU:vatin': '10901232-2-44',
                      'ref:vatin': 'HU10901232', 'brand:wikipedia': 'hu:Magyar Posta Zrt.', 'brand:wikidata': 'Q145614',
-                     'contact:email': 'ugyfelszolgalat@posta.hu', 'phone': '+3617678200',
+                     'contact:email': 'ugyfelszolgalat@posta.hu', 'contact:phone': '+36 1 767 8200',
                      'contact:facebook': 'https://www.facebook.com/MagyarPosta',
                      'contact:youtube': 'https://www.youtube.com/user/magyarpostaofficial',
                      'contact:instagram': 'https://www.instagram.com/magyar_posta_zrt/',

--- a/osm_poi_matchmaker/dataproviders/hu_rossmann.py
+++ b/osm_poi_matchmaker/dataproviders/hu_rossmann.py
@@ -31,7 +31,7 @@ class hu_rossmann(DataProvider):
                      'operator:addr': '2225 Üllő, Zsaróka út 8.', 'ref:HU:vatin': '11149769-2-44',
                      'ref:vatin': 'HU11149769', 'brand': 'Rossmann', 'brand:wikidata': 'Q316004',
                      'brand:wikipedia': 'de:Dirk Rossmann GmbH', 'contact:email': 'ugyfelszolgalat@rossmann.hu',
-                     'phone': '+36 29 889-800;+36 70 4692 800',
+                     'contact:phone': '+36 29 889 800', 'contact:mobile': '+36 70 469 2800',
                      'contact:facebook': 'https://www.facebook.com/Rossmann.hu',
                      'contact:youtube': 'https://www.youtube.com/channel/UCmUCPmvMLL3IaXRBtx7-J7Q',
                      'contact:instagram': 'https://www.instagram.com/rossmann_hu', 'air_conditioning': 'yes'}

--- a/osm_poi_matchmaker/dataproviders/hu_spar.py
+++ b/osm_poi_matchmaker/dataproviders/hu_spar.py
@@ -30,7 +30,7 @@ class hu_spar(DataProvider):
         self.tags = {'operator': 'SPAR Magyarország Kereskedelmi Kft.', 'brand': 'Spar',
                      'brand:wikipedia': 'hu:Spar', 'brand:wikidata': 'Q610492',
                      'contact:email': 'vevoszolgalat@spar.hu',
-                     'phone': '+36208237727', 'contact:facebook': 'https://www.facebook.com/sparmagyarorszag',
+                     'contact:phone': '+36 20 823 7727', 'contact:facebook': 'https://www.facebook.com/sparmagyarorszag',
                      'contact:youtube': 'https://www.youtube.com/channel/UC9tu8COHiy4WkeTIN1k_Y8A',
                      'contact:instagram': 'https://www.instagram.com/sparmagyarorszag'}
         self.tags.update(POS_OTP)

--- a/osm_poi_matchmaker/dataproviders/hu_volanbusz.py
+++ b/osm_poi_matchmaker/dataproviders/hu_volanbusz.py
@@ -33,7 +33,7 @@ class hu_volanbusz(DataProvider):
                      'operator:addr': '1091 Budapest, Üllői út 131.', 'ref:HU:vatin': '10824346-2-44',
                      'ref:vatin': 'HU10824346', 'brand': 'Volánbusz', 'brand:wikidata': 'Q746503',
                      'brand:wikipedia': 'hu:Volánbusz', 'contact:email': 'info@volanbusz.hu',
-                     'phone': '+36 1 219 8000',
+                     'contact:phone': '+36 1 219 8000',
                      'contact:facebook': 'https://www.facebook.com/VOLANBUSZ',
                      'contact:youtube': 'https://www.youtube.com/channel/UCWQ_bIOMja8YYiSwijV2-JQ',
                      'contact:instagram': 'https://www.instagram.com/volanbusz.hu'}


### PR DESCRIPTION
This change makes the phone numbers consistent using **+36 XX XXX XXXX** or **+36 XX XXX XXX** format in the key `contact:phone=*` instead of `phone=*`.