### PR TITLE
Fix LegacyKeyValueFormats in Dockerfiles

### DIFF
--- a/osm_loader.Dockerfile
+++ b/osm_loader.Dockerfile
@@ -1,13 +1,13 @@
 
 FROM alpine:3.11.3
 
-LABEL maintainer Kálmán Szalai (KAMI) <kami911@gmail.com>
+LABEL maintainer="Kálmán Szalai (KAMI) <kami911@gmail.com>"
 
-ENV PATH /usr/local/bin:$PATH
-ENV LANG C.UTF-8
+ENV PATH=/usr/local/bin:$PATH
+ENV LANG=C.UTF-8
 
 # install osm2pgsql
-ENV OSM2PGSQL_VERSION 1.6.0
+ENV OSM2PGSQL_VERSION=1.6.0
 
 RUN apk --no-cache update &&\
     apk add apk-tools && \

--- a/osm_poi_matchmaker.Dockerfile
+++ b/osm_poi_matchmaker.Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.11-slim-bullseye
 
-LABEL maintainer Kálmán Szalai (KAMI) <kami911@gmail.com>
+LABEL maintainer="Kálmán Szalai (KAMI) <kami911@gmail.com>"
 
 # ensure local python is preferred over distribution python
-ENV PATH /usr/local/bin:$PATH
+ENV PATH=/usr/local/bin:$PATH
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 # extra dependencies (over what buildpack-deps already includes)
 RUN apt-get update && apt-get install -y --no-install-recommends \
    build-essential \
@@ -25,7 +25,7 @@ RUN python3.11 --version && \
     python3.11 -m pip install -r /opm/requirements.txt
 
 COPY ./osm_poi_matchmaker /opm/osm_poi_matchmaker
-ENV PYTHONPATH /opm/
+ENV PYTHONPATH=/opm/
 
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD nc opm_db 5432 || exit 1


### PR DESCRIPTION
LegacyKeyValueFormat warnings are raised during Docker builds.

Reference:
https://docs.docker.com/reference/build-checks/legacy-key-value-format/