### PR TITLE
Reduce default logging level to INFO

### DIFF
--- a/osm_poi_matchmaker/log.conf
+++ b/osm_poi_matchmaker/log.conf
@@ -8,12 +8,12 @@ keys=consoleHandler
 keys=consoleFormatter
 
 [logger_root]
-level=DEBUG
+level=INFO
 handlers=consoleHandler
 
 [handler_consoleHandler]
 class=StreamHandler
-level=DEBUG
+level=INFO
 formatter=consoleFormatter
 args=(sys.stdout,)
 


### PR DESCRIPTION
I think that DEBUG should only be enabled manually for testing purposes. It's too verbose for a normal run.