### PR TITLE
Remove unnecessary links attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
       - ../container/osmdata:/opm/osm
     depends_on:
       - db
-    links:
-      - db
     restart: on-failure
     oom_score_adj: -100
     mem_limit: 4g


### PR DESCRIPTION
I think that the `depends_on` attribute is sufficient for this purpose. My tests also confirmed this.

See: https://docs.docker.com/reference/compose-file/services/#links