### PR TITLE
Update Docker files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # OSM POI Matchmaker
-version: "2.2"
 volumes:
   opm_dbdata:
   opm_osmdata:

--- a/osm_poi_matchmaker.Dockerfile
+++ b/osm_poi_matchmaker.Dockerfile
@@ -5,9 +5,7 @@ LABEL maintainer="Kálmán Szalai (KAMI) <kami911@gmail.com>"
 # ensure local python is preferred over distribution python
 ENV PATH=/usr/local/bin:$PATH
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG=C.UTF-8
+ENV LANG=C
 # extra dependencies (over what buildpack-deps already includes)
 RUN apt-get update && apt-get install -y --no-install-recommends \
    build-essential \


### PR DESCRIPTION
- Remove workaround for a fixed CPython bug
- Remove deprecated Compose file top-level element. Source: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete