### PR TITLE
Delete cache tables on startup

### DIFF
--- a/osm_poi_matchmaker/app.conf-template
+++ b/osm_poi_matchmaker/app.conf-template
@@ -9,6 +9,7 @@ db.poi.database=poi
 db.enable.analyze=False
 db.enable.query_log=False
 db.enable.huge_query=False
+db.start.drop.poi_tables=True
 
 # Directory settings
 dir.output=output

--- a/osm_poi_matchmaker/libs/import_poi_data_module.py
+++ b/osm_poi_matchmaker/libs/import_poi_data_module.py
@@ -8,7 +8,9 @@ try:
     import os
     import traceback
     from sqlalchemy.orm import scoped_session, sessionmaker
+    from sqlalchemy import inspect, text
     from osm_poi_matchmaker.dao.poi_base import POIBase
+    from osm_poi_matchmaker.dao.data_structure import POI_OSM_cache, POI_address, POI_address_raw, POI_common, POI_osm, POI_patch
     from osm_poi_matchmaker.utils import config, dataproviders_loader
     from osm_poi_matchmaker.dao.data_handlers import insert_type, get_or_create
 except ImportError as err:
@@ -30,6 +32,8 @@ def import_poi_data_module(module: str):
                                                   config.get_database_writer_host(),
                                                   config.get_database_writer_port(),
                                                   config.get_database_poi_database()))
+        if config.get_database_start_drop_poi_tables():
+            delete_poi_tables(db)
         pgsql_pool = db.pool
         session_factory = sessionmaker(pgsql_pool)
         session_object = scoped_session(session_factory)
@@ -77,3 +81,22 @@ def import_poi_data_module(module: str):
     except Exception as e:
         logging.exception('Exception occurred: {}'.format(e))
         logging.exception(traceback.format_exc())
+
+
+def delete_poi_tables(db: POIBase) -> None:
+    bases_to_drop = [
+        POI_address,
+        POI_address_raw,
+        POI_common,
+        POI_osm,
+        POI_OSM_cache,
+        POI_patch
+    ]
+    
+    with db.engine.connect() as conn:
+        for base in bases_to_drop:
+            table = base.__table__
+            logging.info(f'Dropping table {table.name}...')
+            conn.execute(text(f'DROP TABLE IF EXISTS {table}'))
+    
+    logging.info('Dropped all poi_* tables for a clean start.')

--- a/osm_poi_matchmaker/utils/config.py
+++ b/osm_poi_matchmaker/utils/config.py
@@ -54,6 +54,7 @@ KEY_DATABASE_POI_DATABASE = 'db.poi.database'
 KEY_DATABASE_ENABLE_QUERY_LOG = 'db.enable.query_log'
 KEY_DATABASE_ENABLE_ANALYZE = 'db.enable.analyze'
 KEY_DATABASE_ENABLE_HUGE_QUERY = 'db.enable.huge_query'
+KEY_DATABASE_START_DROP_POI_TABLES = 'db.start.drop.poi_tables'
 KEY_GEO_DEFAULT_PROJECTION = 'geo.default.projection'
 KEY_GEO_DEFAULT_POI_DISTANCE = 'geo.default.poi.distance'
 KEY_GEO_DEFAULT_POI_UNSAFE_DISTANCE = 'geo.default.poi.unsafe.distance'
@@ -219,6 +220,14 @@ def get_database_enable_huge_query():
         return setting
     else:
         return False
+    
+    
+def get_database_start_drop_poi_tables():
+    setting = get_config_bool(KEY_DATABASE_START_DROP_POI_TABLES)
+    if setting is not None:
+        return setting
+    else:
+        return True
 
 
 def get_geo_default_projection():


### PR DESCRIPTION
Delete all `poi_*` tables on every startup
in order to always use the latest tags defined in the code and the latest OSM data.

This is a follow-up PR of #144 because that wasn't merged into the `master` branch 
because I didn't update its target. My bad!