### PR TITLE
Add `User-Agent` header to GLS JSON GET requests

### DIFF
--- a/osm_poi_matchmaker/dataproviders/hu_gls.py
+++ b/osm_poi_matchmaker/dataproviders/hu_gls.py
@@ -74,8 +74,14 @@ class hu_gls(DataProvider):
 
     def process(self):
         try:
-            soup = save_downloaded_soup('{}'.format(self.link), os.path.join(self.download_cache, self.filename),
-                                        self.filetype)
+            soup = save_downloaded_soup(
+                link="{}".format(self.link),
+                file=os.path.join(self.download_cache, self.filename),
+                filetype=self.filetype,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
+                },
+            )
             if soup is not None:
                 text = json.loads(soup, strict=False)
                 for poi_data in text.get('items'):


### PR DESCRIPTION
GLS started blocking all requests with a `4xx` error that have a `User-Agent` header that contains the string `python-requests`. We currently send the following value: `python-requests/2.32.4`.

This commit copies the value used at other data providers. (I've tested and it works this way.)
It also improves formatting.