### PR TITLE
Upgrade Python version from 3.11 to 3.12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,10 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
 
-        - name: Set up latest python3.11
+        - name: Set up latest python3.12
           uses: actions/setup-python@v5
           with:
-              python-version: "3.11.x"
+              python-version: "3.12.x"
 
         - name: Install dependencies
           run: |

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,4 @@
 build:
   environment:
     python:
-      version: 3.11
+      version: 3.12

--- a/osm_poi_matchmaker.Dockerfile
+++ b/osm_poi_matchmaker.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 LABEL maintainer="Kálmán Szalai (KAMI) <kami911@gmail.com>"
 

--- a/osm_poi_matchmaker.Dockerfile
+++ b/osm_poi_matchmaker.Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY ./requirements.txt /opm/requirements.txt
 
-RUN python3.11 --version && \
-    python3.11 -m pip --version && \
-    python3.11 -m pip install -r /opm/requirements.txt
+RUN python3 --version && \
+    python3 -m pip --version && \
+    python3 -m pip install -r /opm/requirements.txt
 
 COPY ./osm_poi_matchmaker /opm/osm_poi_matchmaker
 ENV PYTHONPATH=/opm/

--- a/osm_poi_matchmaker/create_db.py
+++ b/osm_poi_matchmaker/create_db.py
@@ -259,7 +259,7 @@ def main():
         # --- STAGE 6 ---
         logging.info('Starting STAGE 6 – Adding OpenStreetMap metadata fields.')
         # New fields for OpenStreetMap data
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         poi_addr_data['osm_id'] = None
         poi_addr_data['osm_node'] = None
         poi_addr_data['osm_version'] = None

--- a/osm_poi_matchmaker/libs/soup.py
+++ b/osm_poi_matchmaker/libs/soup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import http
 
 try:
     import logging
@@ -48,12 +49,32 @@ def download_content(link, verify_link=config.get_download_verify_link(), post_p
     else:
         logging.warning("Can't save etag value of response: link={} headers={}".format(link, page.headers))
 
-    if page.headers.get('Content-Type') == 'application/zip':
-        logging.debug('Returning a zip file content.')
-        return page.content if page.status_code == 200 else None
+    returned_status = http.HTTPStatus(page.status_code)
+
+    if (
+        returned_status.is_informational
+        or returned_status.is_client_error
+        or returned_status.is_server_error
+    ):
+        suggestion = (
+            "Perhaps you have to add a User-Agent header to the request "
+            "because the API operator bans HTTP requests having default Requests library headers?"
+            if headers is None
+            else "Please check if it works in your browser!"
+        )
+        logging.error(f"{link} returned a {page.status_code} status code. {suggestion}")
+        return None
+    elif returned_status.is_redirection:
+        logging.warning(
+            f"{link} returned a {page.status_code} redirection status code. Please update the URL if it has been moved permanently!"
+        )
+
+    if page.headers.get("Content-Type") == "application/zip":
+        logging.debug("Returning a ZIP file content.")
+        return page.content
     else:
-        logging.debug('Returning a zip file content.')
-        return page.text if page.status_code == 200 else None
+        logging.debug("Returning text content.")
+        return page.text
 
 
 def is_downloaded(link: str, verify_link=config.get_download_verify_link(), headers=None) -> bool:

--- a/test_osm_poi_matchmaker.Dockerfile
+++ b/test_osm_poi_matchmaker.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 LABEL maintainer="Kálmán Szalai (KAMI) <kami911@gmail.com>"
 

--- a/test_osm_poi_matchmaker.Dockerfile
+++ b/test_osm_poi_matchmaker.Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY ./requirements.txt /opm/requirements.txt
 
-RUN python3.11 --version && \
-    python3.11 -m pip --version && \
-    python3.11 -m pip install -r /opm/requirements.txt
+RUN python3 --version && \
+    python3 -m pip --version && \
+    python3 -m pip install -r /opm/requirements.txt
 
 COPY ./osm_poi_matchmaker /opm/osm_poi_matchmaker
 COPY ./test /opm/test


### PR DESCRIPTION
It's just a small step towards the current 3.14 version, but I don't want to break anything.

This makes the new Python 3.12 HTTP status code range properties available.