### PR TITLE
Cast variables to explicit types to avoid exceptions

### DIFF
--- a/osm_poi_matchmaker/libs/osm.py
+++ b/osm_poi_matchmaker/libs/osm.py
@@ -37,7 +37,7 @@ def query_osm_postcode_gpd(session, lon, lat):
         FROM planet_osm_polygon, (SELECT ST_SetSRID(ST_MakePoint(:lon, :lat),4326) as geom) point
         WHERE boundary='postal_code' and ST_Contains(way, point.geom) ORDER BY name LIMIT 1;''')
     try:
-        data = session.execute(query, {'lon': lon, 'lat': lat}).first()
+        data = session.execute(query, {'lon': float(lon), 'lat': float(lat)}).first()
     except Exception as e:
         logging.error(e)
         logging.exception('Exception occurred')
@@ -97,7 +97,7 @@ def query_osm_city_name_gpd(session, lon, lat):
         FROM planet_osm_polygon, (SELECT ST_SetSRID(ST_MakePoint(:lat,:lon),4326) as geom) point
         WHERE admin_level='8' and ST_Contains(way, point.geom) ORDER BY name LIMIT 1;''')
     try:
-        data = session.execute(query, {'lon': lon, 'lat': lat}).first()
+        data = session.execute(query, {'lon': float(lon), 'lat': float(lat)}).first()
     except Exception as e:
         logging.error(e)
         logging.exception('Exception occurred')

--- a/osm_poi_matchmaker/libs/poi_dataset.py
+++ b/osm_poi_matchmaker/libs/poi_dataset.py
@@ -107,7 +107,7 @@ class POIDatasetRaw:
         self.__lat = None
         self.__lon = None
         self.__nonstop = None
-        self.__oh = pd.DataFrame(index=WeekDaysShort, columns=OpenClose)
+        self.__oh = pd.DataFrame(index=list(WeekDaysShort), columns=list(OpenClose))
         self.__lunch_break_start = None
         self.__lunch_break_stop = None
         self.__opening_hours = None
@@ -171,7 +171,7 @@ class POIDatasetRaw:
         self.__lat = None
         self.__lon = None
         self.__nonstop = None
-        self.__oh = pd.DataFrame(index=WeekDaysShort, columns=OpenClose)
+        self.__oh = pd.DataFrame(index=list(WeekDaysShort), columns=list(OpenClose))
         self.__lunch_break_start = None
         self.__lunch_break_stop = None
         self.__opening_hours = None
@@ -701,7 +701,7 @@ class POIDatasetRaw:
 
     @opening_hours_table.setter
     def opening_hours_table(self, data):
-        self.__oh = pd.DataFrame(data, index=WeekDaysShort, columns=OpenClose)
+        self.__oh = pd.DataFrame(data, index=list(WeekDaysShort), columns=list(OpenClose))
 
     @property
     def nonstop(self) -> bool:


### PR DESCRIPTION
I.e. `Enum`s to `list`s and coordinates to `float`.