### PR TITLE
Fix CI/CD: stop Codacy Security Scan from failing every build

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -25,7 +25,11 @@ jobs:
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@4.0.2
+        uses: codacy/codacy-analysis-cli-action@4.4.7
+        # No CODACY_PROJECT_TOKEN secret is configured for this repo, so the
+        # action can fail to fetch remote tool patterns (e.g. SQLint).
+        # Don't let that fail the whole workflow/PR check.
+        continue-on-error: true
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
@@ -37,8 +41,9 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
-      # Upload the SARIF file generated in the previous step
+      # Upload the SARIF file generated in the previous step, if any
       - name: Upload SARIF results file
+        if: hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- No `CODACY_PROJECT_TOKEN` secret is configured on this repo, so `codacy-analysis-cli-action` fails to fetch remote tool patterns (e.g. SQLint) and errors out with "No credentials found" on every push/PR
- Bumps the action from the very outdated `4.0.2` to the latest `4.4.7`
- Marks the analysis step `continue-on-error: true` so a missing token no longer fails every check, matching the workflow's own stated intent of handing PR-rejection control to GitHub rather than to this scan
- SARIF upload now only runs if a results file was actually produced

Fixes #196

To get real Codacy analysis results (instead of just not failing), add a `CODACY_PROJECT_TOKEN` secret from your Codacy project settings.

## Test plan
- [ ] Confirm the workflow run on this PR shows Codacy Security Scan as passing (or skipped upload) instead of red